### PR TITLE
(feat) Add ordered dependency output as an option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,7 +65,8 @@ module.exports = function(grunt) {
                     extractDeclared: function(filepath) {
                         return [filepath];
                     },
-                    onlyConcatRequiredFiles: true
+                    onlyConcatRequiredFiles: true,
+                    dependencyOutputPath: 'tmp/ordered_dependencies.json'
                 }
             }
         },

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ grunt.initConfig({
           this is a default function that extracts declared modules names from file content
           extractDeclared: function (filepath, filecontent) {
             return this.getMatches(/declare\(['"]([^'"]+)['"]/g, filecontent);
-          }
+          },
+          this is an optional path which when declared will output JSON containing the ordered dependencies
+          dependencyOutputPath: '/build/ordered_dependencies.json'
           */
       },
       files: {

--- a/tasks/concat_in_order.js
+++ b/tasks/concat_in_order.js
@@ -157,6 +157,13 @@ module.exports = function (grunt) {
                 }
             }
 
+            if (options.dependencyOutputPath) {
+                grunt.file.write(options.dependencyOutputPath, JSON.stringify(ordered.map(function(item) {
+                    return item.file;
+                })));
+                grunt.log.writeln('Dependency file "' + options.dependencyOutputPath + '" created.');
+            }
+
             grunt.file.write(fileSet.dest, ordered.map(function (item) {
                 return item.content;
             }).join(EOL));

--- a/test/concat_in_order_test.js
+++ b/test/concat_in_order_test.js
@@ -37,11 +37,15 @@ exports.concat_in_order = {
     test.done();
   },
   filebased_options : function(test) {
-    test.expect(1);
+    test.expect(2);
 
     var actual = grunt.file.read('tmp/filebased_options.js');
     var expected = grunt.file.read('test/expected/filebased_options.js');
     test.equal(actual, expected, 'should include files automatically when filebased');
+
+    var actualDependencies = grunt.file.read('tmp/ordered_dependencies.json');
+    var expectedDependencies = grunt.file.read('test/expected/ordered_dependencies.json');
+    test.equal(actualDependencies, expectedDependencies, 'should write the dependencies in order');
 
     test.done();
   }

--- a/test/expected/ordered_dependencies.json
+++ b/test/expected/ordered_dependencies.json
@@ -1,0 +1,1 @@
+["test/filebased/BaseA.js","test/filebased/AUsingBaseA.js","test/filebased/BaseBUsingBaseA.js","test/filebased/AUsingBaseBAndBaseA.js"]


### PR DESCRIPTION
This option helps to sourcemap generation with another grunt task
