### PR TITLE
fixing path

### DIFF
--- a/tasks/concat_in_order.js
+++ b/tasks/concat_in_order.js
@@ -121,7 +121,7 @@ module.exports = function (grunt) {
             getExistingFiles(fileSet).map(function extractAndAddDependencies(filepath) {
                 //do not process this file again if already added
                 if (depsTree.some(function(item) {
-                    return item.file === path.resolve(path.normalize(filepath));
+                    return path.resolve(item.file) === path.resolve(path.normalize(filepath));
                 })) {
                     return;
                 }

--- a/tasks/concat_in_order.js
+++ b/tasks/concat_in_order.js
@@ -121,7 +121,7 @@ module.exports = function (grunt) {
             getExistingFiles(fileSet).map(function extractAndAddDependencies(filepath) {
                 //do not process this file again if already added
                 if (depsTree.some(function(item) {
-                    return item.file === path.normalize(filepath);
+                    return item.file === path.resolve(path.normalize(filepath));
                 })) {
                     return;
                 }

--- a/tasks/concat_in_order.js
+++ b/tasks/concat_in_order.js
@@ -15,6 +15,7 @@ module.exports = function (grunt) {
 
     var defaultOptions = {
         banner: '',
+        footer: '',
         getMatches: function (regex, string, index) {
             var matches = [], match;
             if(arguments.length < 3){
@@ -30,7 +31,8 @@ module.exports = function (grunt) {
         },
         extractDeclared: function (filepath, filecontent) {
             return this.getMatches(/declare\(['"]([^'"]+)['"]/g, filecontent);
-        }
+        },
+        processContent: undefined
     }, getExistingFiles = function (files) {
         return files.src.filter(function (filepath) {
             // Warn on and remove invalid source files (if nonull was set).
@@ -159,8 +161,8 @@ module.exports = function (grunt) {
             }
 
             grunt.file.write(fileSet.dest, options.banner + ordered.map(function (item) {
-                return item.content;
-            }).join(EOL));
+                return options.processContent ? options.processContent( item.content) : item.content;
+            }).join(EOL) +options.footer);
 
             grunt.log.writeln('File "' + fileSet.dest + '" created.');
         });

--- a/tasks/concat_in_order.js
+++ b/tasks/concat_in_order.js
@@ -138,7 +138,7 @@ module.exports = function (grunt) {
 
                 depsTree.push({
                     content: content,
-                    file: path.normalize(filepath),
+                    file: path.resolve( path.normalize(filepath) ),
                     required: required,
                     declared: declared
                 });


### PR DESCRIPTION
We use the following options to use the task. 
Basically we extract the dependencies from a comment with a @require tag

`concat_in_order: {
      options: {
        extractRequired: function(filepath, filecontent) {
          var path = require("path");
          var base = path.resolve(grunt.config.data[grunt.task.current.name][grunt.task.current.target].options.baseSrc);
          var workingdir = base.split(path.sep);
          // in case of unix path 
          if (base.charAt(0) == path.sep) workingdir.unshift(path.sep);
          var xtractedDdeps = this.getMatches(/\*\s*@require\s(.*\.js)/g, filecontent);
          xtractedDdeps.forEach(function(dep, i) {

            var dependency = workingdir.concat([dep]);

            xtractedDdeps[i] = path.join.apply(null, dependency);
          //                        console.log(deps[i]);
          });
          return xtractedDdeps;
        },
        extractDeclared: function(filepath) {
          var path = require("path");
          return [path.resolve(filepath)];
        },
        onlyConcatRequiredFiles: true
      },`

when doing this I've noticed the mechanism of file comparisons (line 123 of concat_in_order.js) compares absolute path with relative. 
So I propose to add a path.resolve call to ensure the comparison will be correct every time. 