### PR TITLE
Added option to output concatenation order to file (newline seperated).

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,7 +65,8 @@ module.exports = function(grunt) {
                     extractDeclared: function(filepath) {
                         return [filepath];
                     },
-                    onlyConcatRequiredFiles: true
+                    onlyConcatRequiredFiles: true,
+                    exportConcatenationOrder: undefined
                 }
             }
         },

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ grunt.initConfig({
           this is a default function that extracts declared modules names from file content
           extractDeclared: function (filepath, filecontent) {
             return this.getMatches(/declare\(['"]([^'"]+)['"]/g, filecontent);
-          }
+          },
+          export the path of all concated files in their concatenation (newline seperated) to this file
+          exportConcatenationOrder: undefined
           */
       },
       files: {

--- a/tasks/concat_in_order.js
+++ b/tasks/concat_in_order.js
@@ -163,6 +163,11 @@ module.exports = function (grunt) {
             }).join(EOL));
 
             grunt.log.writeln('File "' + fileSet.dest + '" created.');
+
+            if (options.exportConcatenationOrder) {
+                grunt.file.write(options.exportConcatenationOrder, ordered.map(item => item.file).join("\n"));
+                grunt.log.writeln('Concatenation order exported to "' + options.exportConcatenationOrder + '".');
+            }
         });
     });
 


### PR DESCRIPTION
I needed the concatenation order to be exported as a file (newline based).
I use concat-in-order to build a JS-library, but sometimes it is nice to import all scripts manually.
This is often beneficial in the development process.
This patch avoids figuring out the import order manually.

This pull request is similar (but not identical) to:

https://github.com/miensol/grunt-concat-in-order/pull/6/commits/4f878f2e86714315a218d9c6f153ac17a7140312